### PR TITLE
Add note to differentiate from golang.org/x/oauth2/jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 # jwt
 This is a minimal implementation of JWT designed with simplicity in mind.
 
-#What is JWT?
+# What is JWT?
 Jwt is a signed JSON object used for claims based authentication. A good resource on what JWT Tokens are is [jwt.io](https://jwt.io/), and in addition you can always read the [RFC](https://tools.ietf.org/html/rfc7519).
 
 This implementation doesn't fully follow the specs in that it ignores the algorithm claim on the header. It does this due to the security vulnerability in the JWT specs. Details on the vulnerability can be found [here](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/)
 
-##What algorithms does it support?
+## What algorithms does it support?
 * HS256
 * HS384
 * HS512
 
-##How does it work?
+## How does it work?
 
-###How to create a token?
+### How to create a token?
 Creating a token is actually pretty easy.
 
 The first step is to pick a signing method. For demonstration purposes we will choose HSMAC256.
@@ -34,14 +34,14 @@ Then we will need to sign it!
         panic(err)    
     }
     
-###How to authenticate a token?
+### How to authenticate a token?
 Authenticating a token is quite simple. All we need to do is...
 
     if algorithm.Validate(token) == nil {
         //authenticated
     } 
     
-###How do we get the claims?
+### How do we get the claims?
 The claims are stored in a `Claims` struct. To get the claims from a token simply...
     
     claims, err := algorithm.Decode(token)
@@ -52,3 +52,7 @@ The claims are stored in a `Claims` struct. To get the claims from a token simpl
     if strings.Compare(role, "Admin") {
         //user is an admin    
     }
+    
+    
+### How is it different from golang.org/x/oauth2/jwt?
+This package contains just the logic for `jwt` encoding, decoding, and verification. The `golang.org/x/oauth2/jwt` package does not implement the `jwt` specifications. Instead it is specifically tied to `oauth2`, requiring a `TokenURL`, `email` and can only use a specific algorithm (RSA).


### PR DESCRIPTION
Added a note to differentiate this package from the `golang.org/x/oauth2/jwt` package

Made in response to #8 
