### PR TITLE
Algorithm.Sign() was pre-encoding the signature; the rest of the lib then double encoded them

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -41,13 +41,13 @@ func (a *Algorithm) write(data []byte) (int, error) {
 }
 
 // Sign signs the token with the given hash, and key
-func (a *Algorithm) Sign(unsignedToken string) (string, error) {
+func (a *Algorithm) Sign(unsignedToken string) ([]byte, error) {
 	_, err := a.write([]byte(unsignedToken))
 	if err != nil {
-		return "", errors.Wrap(err, "Unable to write to HMAC-SHA256")
+		return nil, errors.Wrap(err, "Unable to write to HMAC-SHA256")
 	}
 
-	encodedToken := base64.RawURLEncoding.EncodeToString(a.sum(nil))
+	encodedToken := a.sum(nil)
 	a.reset()
 
 	return encodedToken, nil

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -24,8 +24,8 @@ func RunTest(t *testing.T, command func(Algorithm)) {
 func TestEncodeAndValidateToken(t *testing.T) {
 	RunTest(t, func(algorithm Algorithm) {
 		payload := NewClaim()
-		payload.SetTime("nbf", time.Now().Add(time.Duration(-1) * time.Hour))
-		payload.SetTime("exp", time.Now().Add(time.Duration(100) * time.Hour))
+		payload.SetTime("nbf", time.Now().Add(time.Duration(-1)*time.Hour))
+		payload.SetTime("exp", time.Now().Add(time.Duration(100)*time.Hour))
 
 		token, err := algorithm.Encode(payload)
 		if err != nil {
@@ -90,7 +90,7 @@ func TestVerifyTokenNbf(t *testing.T) {
 	RunTest(t, func(algorithm Algorithm) {
 
 		payload := NewClaim()
-		payload.SetTime("nbf", time.Now().Add(time.Duration(1) * time.Hour))
+		payload.SetTime("nbf", time.Now().Add(time.Duration(1)*time.Hour))
 
 		err := json.Unmarshal([]byte(`{"sub":"1234567890","name":"John Doe","admin":true}`), &payload)
 		if err != nil {
@@ -119,4 +119,15 @@ func TestDecodeMalformedToken(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestValidateExternalToken(t *testing.T) {
+	token := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImp0aSI6ImZmNzJkMWM5LTMzMTktNGIyOS04YjlhLWU1OThkNGJhNDRlZCJ9.eyJpc3MiOiJodHRwOi8vbG9jYWwuaG9zdC5jb20iLCJhdWQiOiJodHRwOi8vbG9jYWwuaG9zdC5jb20iLCJqdGkiOiJmZjcyZDFjOS0zMzE5LTRiMjktOGI5YS1lNTk4ZDRiYTQ0ZWQiLCJpYXQiOjE1MTkzMjc2NDYsIm5iZiI6MTUxOTMyNzY1MCwiZXhwIjoxNjQwMzkwNDAwfQ.ASo8eiekkwZ7on43S9n697x-SqmdehY680GetK_KqpI"
+
+	algorithm := HmacSha256("this-needs-a-test")
+
+	err := algorithm.Validate(token)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Externally created tokens were failing to validate, it turns out that signatures were being double encoded.

I used the debugger at [jwt.io](https://jwt.io/) to confirm.